### PR TITLE
use secure_compare to compare tokens securely

### DIFF
--- a/app/controllers/credible/authentication/users_controller.rb
+++ b/app/controllers/credible/authentication/users_controller.rb
@@ -32,10 +32,10 @@ class Credible::Authentication::UsersController < Credible::AuthenticationContro
   # GET /users/confirm/:confirmation_token
   # GET /users/confirm/:confirmation_token.json
   def confirm
-    @user = ::User.find_by(confirmation_token: params[:confirmation_token])
+    @user = ::User.find_by(email: params[:email])
     authorize @user
 
-    @user.confirm
+    @user.confirm(params[:confirmation_token])
 
     if @user.save
       @session = current_user ? current_session : ::Session.create(user: @user)

--- a/app/mailers/credible/user_mailer.rb
+++ b/app/mailers/credible/user_mailer.rb
@@ -5,7 +5,7 @@ class Credible::UserMailer < ApplicationMailer
     @app_name = Rails.application.class.module_parent_name
     @user = params[:user]
     @url  = root_url
-    @confirmation_url = @url + 'confirm/' + @user.confirmation_token
+    @confirmation_url = @url + 'confirm/' + @user.confirmation_token + '?email=' + @user.email
     mail(to: @user.email, subject: "Welcome to #{@app_name} | Please confirm your account")
   end
 

--- a/lib/credible/user.rb
+++ b/lib/credible/user.rb
@@ -20,10 +20,12 @@ module Credible
       validates_confirmation_of :password, allow_blank: true
       # End custom password validation
 
-      def confirm
-        self.confirmation_token = nil
-        self.password = SecureRandom.hex(8) unless password_digest.present?
-        self.confirmed_at = Time.now.utc
+      def confirm(token = nil)
+        if ActiveSupport::SecurityUtils.secure_compare(token, confirmation_token)
+          self.confirmation_token = nil
+          self.password = SecureRandom.hex(8) unless password_digest.present?
+          self.confirmed_at = Time.now.utc
+        end
       end
 
       def confirmed?


### PR DESCRIPTION
## Linked Issue(s)

- closes #2 

## Description

### Feature

User secure_compare to mitigate timing attacks and provide a more secure use of confirmation tokens.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
