### PR TITLE
add IAT and EXP to JWT and verify in Warden

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -25,8 +25,9 @@ Warden::Strategies.add(:jwt) do
       jwt = header.gsub(pattern, '') if header && header.match(pattern)
       token =
         JWT.decode jwt, Rails.application.secrets.secret_key_base, true,
-                   iss: Rails.application.class.module_parent_name, verify_iss: true, algorithm: 'HS256' # [1]
-    rescue JWT::InvalidIssuerError
+                   iss: Rails.application.class.module_parent_name, 
+                   verify_iss: true, verify_iat: true, algorithm: 'HS256' # [1]
+    rescue JWT::InvalidIssuerError, JWT::InvalidIatError, JWT::ExpiredSignature
       fail!('Could not authenticate')
     end
 

--- a/lib/credible/session.rb
+++ b/lib/credible/session.rb
@@ -12,7 +12,9 @@ module Credible
       def jwt
         payload = {
           data: jwt_data,
-          iss: Rails.application.class.module_parent_name
+          iss: Rails.application.class.module_parent_name,
+          iat: Time.now.to_i,
+          exp: Time.now.to_i + 4 * 3600
         }
         JWT.encode payload, Rails.application.secrets.secret_key_base, 'HS256' # [1]
       end


### PR DESCRIPTION
## Linked Issue(s)

- closes #24 

## Description

### Feature

Adds expiration to JWTs and verifies Issued at Time as well. The first part of this, EXP, will mean that the user now has to reauthenticate every four hours.

This raises the scary prospect of being signed out when trying to submit some new data - this is something that the consuming application must be aware of and appropriately handle... My thinking is... `IF response == 401 THEN present sign in modal`. That way, the page isn't lost and a resubmit can be performed after receiving a new JWT. My present approach... redirection... will need fixing. Could implement **polling** to check session still valid...

...but really, that's going to be semi-redundant once Refresh Tokens are implemented in the next PR.

Okay, DON'T MERGE YET. Merge when Refresh Token also implemented. Implement RT to be as non-disruptive as possible, meaning application should still work (albeit session becoming invalid in four hours) without reworking.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
