### PR TITLE
create ephemeral session with user as attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Access token remains valid until expiry - authentication no longer depends on Session still existing
+
 ## [0.12.0]
 
 ### Added
@@ -59,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0]
 
-[Unreleased]: https://github.com/thombruce/credible/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/thombruce/credible/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/thombruce/credible/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/thombruce/credible/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/thombruce/credible/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/thombruce/credible/compare/v0.9.0...v0.9.1

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -33,7 +33,8 @@ Warden::Strategies.add(:jwt) do
       fail!('Could not authenticate')
     end
 
-    session = ::Session.find(token[0]['data']['session_id'])
+    user = ::User.find(token[0]['data']['user_id'])
+    session = ::Session.new(user: user)
     success!(session)
   rescue # ActiveRecord::RecordNotFound
     fail!('Could not authenticate')


### PR DESCRIPTION
## Linked Issue(s)

- closes #32 

## Description

### Bugfix

Allows access tokens to remain valid until expiry, even if their associated session has been destroyed. This allows us to refresh the refresh token and obtain a separate access token in another tab, while our old access token should still work in the original tab.

_Refresh token should also be updated in localStorage. This should need no additional configuration, but the application should be aware of when accessToken is due to expire and issue a refresh request._

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn/blob/master/CODE_OF_CONDUCT.md)
